### PR TITLE
chore: ignore generated incidents file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 node_modules
 .DS_Store
 .uclirc.yml
+.incidents.yml
 history

--- a/.incidents.yml
+++ b/.incidents.yml
@@ -1,2 +1,0 @@
-useID: 1
-incidents: {}


### PR DESCRIPTION
## Summary
- Removes the generated `.incidents.yml` stub that was accidentally committed while refreshing docs
- Adds `.incidents.yml` to `.gitignore` so local CLI runs do not reintroduce it

## Test plan
- `git diff --cached --check`
- `git check-ignore .incidents.yml`
- Added-lines security scan: no findings
- Independent diff review: passed
